### PR TITLE
Upgrade procyon-compilertools to 0.5.34 to support OpenJDK11

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -11,7 +11,7 @@
 (set-env! :resource-paths #{"src"}
           :source-paths   #{"src"}
           :dependencies   '[[org.clojure/clojure "1.10.0" :scope "provided"]
-                            [org.bitbucket.mstrobel/procyon-compilertools "0.5.29"]])
+                            [org.bitbucket.mstrobel/procyon-compilertools "0.5.34"]])
 
 (deftask build
   "Build the project."


### PR DESCRIPTION
I've had difficulty using clj-java-decompiler locally due to problems with a missing sun/misc/URLClassPath. I believe this is related to the upstream issue of https://bitbucket.org/mstrobel/procyon/issues/320/java-9-sunmiscurlclasspath-and, or https://bitbucket.org/mstrobel/procyon/issues/330/no-class-defined-sunmiscurlclasspath,
but appears semi resolved in version 0.5.34.

So I created a minimum reproducible example:

Locally I'm using OpenJDK 11

```
$ java -version
openjdk version "11.0.1" 2018-10-16
OpenJDK Runtime Environment (build 11.0.1+13-Ubuntu-3ubuntu3.18.10.1)
OpenJDK 64-Bit Server VM (build 11.0.1+13-Ubuntu-3ubuntu3.18.10.1, mixed mode, sharing)
```

deps.edn
```
{:deps
 {org.clojure/clojure {:mvn/version "1.10.0"}
  com.clojure-goes-fast/clj-java-decompiler {:mvn/version "0.2.1"}
  }
 :aliases
 {:perf {:override-deps {org.bitbucket.mstrobel/procyon-compilertools {:mvn/version "0.5.34"}}}}}
```

src/decompile/core.clj
```
(ns decompile.core
  (:require [clj-java-decompiler.core :refer [decompile]]))

(println (decompile (dotimes [i 5] (println i))))
```

If I run the tools using clj

```
$ clj src/decompile/core.clj
0
1
2
3
4
Exception in thread "main" Syntax error compiling at (/home/clgc/code/clojure/decompile/src/decompile/core.clj:4:1).
        at clojure.lang.Compiler.load(Compiler.java:7647)
        at clojure.lang.Compiler.loadFile(Compiler.java:7573)
        at clojure.main$load_script.invokeStatic(main.clj:452)
        at clojure.main$script_opt.invokeStatic(main.clj:512)
        at clojure.main$script_opt.invoke(main.clj:507)
        at clojure.main$main.invokeStatic(main.clj:598)
        at clojure.main$main.doInvoke(main.clj:561)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at clojure.lang.Var.applyTo(Var.java:705)
        at clojure.main.main(main.java:37)
Caused by: java.lang.NoClassDefFoundError: sun/misc/URLClassPath
        at com.strobel.assembler.metadata.ClasspathTypeLoader.<init>(ClasspathTypeLoader.java:66)
        at com.strobel.assembler.metadata.ClasspathTypeLoader.<init>(ClasspathTypeLoader.java:42)
        at com.strobel.assembler.metadata.MetadataSystem.<init>(MetadataSystem.java:48)
        at com.strobel.assembler.metadata.MetadataSystem.instance(MetadataSystem.java:40)
        at com.strobel.assembler.metadata.PrimitiveType.<init>(PrimitiveType.java:28)
        at com.strobel.assembler.metadata.BuiltinTypes.<clinit>(BuiltinTypes.java:40)
        at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method)
        at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized(Unsafe.java:1042)
        at jdk.unsupported/sun.misc.Unsafe.ensureClassInitialized(Unsafe.java:698)
        at com.strobel.compilerservices.RuntimeHelpers.ensureClassInitialized(RuntimeHelpers.java:31)
        at com.strobel.assembler.metadata.MetadataSystem.<clinit>(MetadataSystem.java:147)
        at clj_java_decompiler.core$resolve_class_from_file.invokeStatic(core.clj:52)
        at clj_java_decompiler.core$resolve_class_from_file.invoke(core.clj:52)
        at clj_java_decompiler.core$decompile_classfile.invokeStatic(core.clj:64)
        at clj_java_decompiler.core$decompile_classfile.invoke(core.clj:61)
        at clj_java_decompiler.core$decompile_form$fn__180.invoke(core.clj:82)
        at clojure.core$run_BANG_$fn__8775.invoke(core.clj:7715)
        at clojure.core.protocols$fn__8144.invokeStatic(protocols.clj:168)
        at clojure.core.protocols$fn__8144.invoke(protocols.clj:124)
        at clojure.core.protocols$fn__8099$G__8094__8108.invoke(protocols.clj:19)
        at clojure.core.protocols$seq_reduce.invokeStatic(protocols.clj:31)
        at clojure.core.protocols$fn__8131.invokeStatic(protocols.clj:75)
        at clojure.core.protocols$fn__8131.invoke(protocols.clj:75)
        at clojure.core.protocols$fn__8073$G__8068__8086.invoke(protocols.clj:13)
        at clojure.core$reduce.invokeStatic(core.clj:6828)
        at clojure.core$run_BANG_.invokeStatic(core.clj:7710)
        at clojure.core$run_BANG_.invoke(core.clj:7710)
        at clj_java_decompiler.core$decompile_form.invokeStatic(core.clj:82)
        at clj_java_decompiler.core$decompile_form.invoke(core.clj:76)
        at decompile.core$eval198.invokeStatic(core.clj:4)
        at decompile.core$eval198.invoke(core.clj:4)
        at clojure.lang.Compiler.eval(Compiler.java:7176)
        at clojure.lang.Compiler.load(Compiler.java:7635)
        ... 9 more
Caused by: java.lang.ClassNotFoundException: sun.misc.URLClassPath
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:583)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
        ... 42 more
```

However if I override the procyon version to 0.5.34 I get:

```
$ clj -A:perf src/decompile/core.clj
0
1
2
3
4

// Decompiling class: decompile/core$fn__200
package decompile;

import clojure.lang.*;

public final class core$fn__200 extends AFunction
{
    public static final Var const__4;

    public static Object invokeStatic() {
        for (long n__6006__auto__202 = 5L, i = 0L; i < n__6006__auto__202; ++i) {
            ((IFn)core$fn__200.const__4.getRawRoot()).invoke(Numbers.num(i));
        }
        return null;
    }

    @Override
    public Object invoke() {
        return invokeStatic();
    }

    static {
        const__4 = RT.var("clojure.core", "println");
    }
}

nil
```